### PR TITLE
Disable Linux build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-13, macos-12, macos-11]
+        os: [macos-13, macos-12, macos-11]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
This Linux build fails with this error:

    Error: No available formula with the name "cmake".

No clue why there's no `cmake` for Linux ... but anyway, we don't really need Linux packages anyway.