### PR TITLE
Remove macos-11 from the CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-14, macos-13, macos-12, macos-11]
+        os: [ubuntu-22.04, macos-14, macos-13, macos-12]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew


### PR DESCRIPTION
... because no bottles are built for it anymore.