### PR TITLE
SSR: depend on version 10 of the fmt library

### DIFF
--- a/Formula/ssr.rb
+++ b/Formula/ssr.rb
@@ -18,7 +18,7 @@ class Ssr < Formula
   depends_on "asio"
   depends_on "ecasound"
   depends_on "fftw"
-  depends_on "fmt" "10"
+  depends_on "fmt" => "10"
   depends_on "jack"
   depends_on "libsndfile"
   depends_on "qt@5"

--- a/Formula/ssr.rb
+++ b/Formula/ssr.rb
@@ -18,7 +18,7 @@ class Ssr < Formula
   depends_on "asio"
   depends_on "ecasound"
   depends_on "fftw"
-  depends_on "fmt" => "10"
+  depends_on "fmt@10"
   depends_on "jack"
   depends_on "libsndfile"
   depends_on "qt@5"

--- a/Formula/ssr.rb
+++ b/Formula/ssr.rb
@@ -18,7 +18,7 @@ class Ssr < Formula
   depends_on "asio"
   depends_on "ecasound"
   depends_on "fftw"
-  depends_on "fmt", "10"
+  depends_on fmt: "10"
   depends_on "jack"
   depends_on "libsndfile"
   depends_on "qt@5"

--- a/Formula/ssr.rb
+++ b/Formula/ssr.rb
@@ -18,7 +18,7 @@ class Ssr < Formula
   depends_on "asio"
   depends_on "ecasound"
   depends_on "fftw"
-  depends_on fmt: "10"
+  depends_on "fmt" "10"
   depends_on "jack"
   depends_on "libsndfile"
   depends_on "qt@5"

--- a/Formula/ssr.rb
+++ b/Formula/ssr.rb
@@ -18,7 +18,7 @@ class Ssr < Formula
   depends_on "asio"
   depends_on "ecasound"
   depends_on "fftw"
-  depends_on "fmt@10"
+  depends_on "fmt" => "10.2.1"
   depends_on "jack"
   depends_on "libsndfile"
   depends_on "qt@5"

--- a/Formula/ssr.rb
+++ b/Formula/ssr.rb
@@ -18,7 +18,7 @@ class Ssr < Formula
   depends_on "asio"
   depends_on "ecasound"
   depends_on "fftw"
-  depends_on "fmt"
+  depends_on "fmt", "10"
   depends_on "jack"
   depends_on "libsndfile"
   depends_on "qt@5"


### PR DESCRIPTION
This tries to pin the version of `libfmt`, but I'm not sure if that's the right syntax (nor if that works at all).

See #32.