### PR TITLE
ssr: bump revision to get newest libfmt version

### DIFF
--- a/Formula/ssr.rb
+++ b/Formula/ssr.rb
@@ -4,7 +4,7 @@ class Ssr < Formula
   url "https://github.com/SoundScapeRenderer/ssr/releases/download/0.6.1/ssr-0.6.1.tar.gz"
   sha256 "392a13ecbf86f980be76a31884a83ab762e577c1c829cb5e744f708542bc5bdb"
   license "GPL-3.0-or-later"
-  revision 1
+  revision 2
 
   bottle do
     root_url "https://github.com/SoundScapeRenderer/homebrew-ssr/releases/download/ssr-0.6.1_1"


### PR DESCRIPTION
This should create bottles which depend on `libfmt` version 11.

See #32.